### PR TITLE
use pkg-config libdir variable instead of hardcoding lib

### DIFF
--- a/garden.yaml
+++ b/garden.yaml
@@ -13,7 +13,7 @@ garden:
 
 variables:
   jobs: $ nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8
-  libdir: lib
+  libdir: $ PKG_CONFIG_PATH=${GARDEN_ROOT}/ptex/dist/share/pkgconfig pkg-config --variable=libdir ptex
 
 commands:
   watch: |
@@ -33,7 +33,7 @@ trees:
     url: "git@github.com:vfx-rs/ptex-bind.git"
     path: ${GARDEN_CONFIG_DIR}
     environment:
-      LD_LIBRARY_PATH: ${GARDEN_ROOT}/ptex/dist/${libdir}
+      LD_LIBRARY_PATH: ${libdir}
       PKG_CONFIG_PATH: ${GARDEN_ROOT}/ptex/dist/share/pkgconfig
     commands:
       build: cargo build --all "$@"


### PR DESCRIPTION
this fixes `garden test` in the case where the libdir is `lib64` rather than the `lib` that was hard coded.