### PR TITLE
Make `Cache::get` take `AsRef<Path>`

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -45,9 +45,9 @@ impl Cache {
     /// Return a cached Ptex Reader for the specified filename.
     /// The filename be either an absolute path, a relative path, or a path
     /// relative to the Ptex search path.
-    pub fn get(&mut self, filename: &std::path::Path) -> Result<Texture, Error> {
+    pub fn get<P: AsRef<std::path::Path>>(&mut self, filename: P) -> Result<Texture, Error> {
         let_cxx_string!(error_str = "");
-        let filename_str = filename.to_string_lossy().to_string();
+        let filename_str = filename.as_ref().to_string_lossy().to_string();
         let texture = unsafe {
             sys::ptexcache_get(
                 self.0,
@@ -57,7 +57,7 @@ impl Cache {
         };
 
         if texture.is_null() {
-            let default_error_message = format!("ptex: Cache::get({:?}) failed", filename);
+            let default_error_message = format!("ptex: Cache::get({:?}) failed", filename.as_ref());
             if error_str.is_empty() {
                 return Err(Error::Message(error_str.to_string()));
             }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -3,8 +3,11 @@ use crate::{BorderMode, DataType, EdgeFilterMode, FaceInfo, MeshType};
 
 /// Interface for reading data from a ptex file
 ///
-/// PtexTexture instances can be acquired via the ptexwriter_open() function, or via the
-/// PtexCache interface.
+/// PtexTexture instances can be acquired via any of the following methods
+///
+/// * from this crate with [`Cache::get()`](crate::Cache::get`).
+/// * from [ptex_sys] using the [ptex_writer()](ptex_sys::ffi::ptexwriter_open) function\
+///   or [PtexCache](ptex_sys::ffi::PtexCache) interface.
 ///
 /// Data access through this interface is returned in v-major order with all data channels
 /// interleaved per texel.


### PR DESCRIPTION
This makes the argument a little more convenient to use, e.g. so you can now also `Cache::get("filename.ptx")`.
It also updates the texture docs to reference `Cache::get`, and make links clickable.