### PR TITLE
Make MeshType an enum

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,4 +8,7 @@ pub enum Error {
     /// General error messages.
     #[error("{0:?}")]
     Message(String),
+
+    #[error("{0}")]
+    EnumConversion(#[from] crate::types::EnumConversionError),
 }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,5 +1,5 @@
 use crate::sys;
-use crate::{BorderMode, DataType, EdgeFilterMode, FaceInfo, MeshType};
+use crate::{BorderMode, DataType, EdgeFilterMode, Error, FaceInfo, MeshType};
 
 /// Interface for reading data from a ptex file
 ///
@@ -55,28 +55,28 @@ impl Texture {
     }
 
     /// Return the ptex::MeshType for the Texture.
-    pub fn mesh_type(&self) -> MeshType {
-        MeshType::from(unsafe { sys::ptextexture_get_meshtype(self.0) })
+    pub fn mesh_type(&self) -> Result<MeshType, Error> {
+        MeshType::try_from(unsafe { sys::ptextexture_get_meshtype(self.0) })
     }
 
     /// Return the ptex::DataType for the Texture.
-    pub fn data_type(&self) -> DataType {
-        DataType::from(unsafe { sys::ptextexture_get_datatype(self.0) })
+    pub fn data_type(&self) -> Result<DataType, Error> {
+        DataType::try_from(unsafe { sys::ptextexture_get_datatype(self.0) })
     }
 
     /// Return the border mode in the U direction.
-    pub fn border_mode_u(&self) -> BorderMode {
-        BorderMode::from(unsafe { sys::ptextexture_get_border_mode_u(self.0) })
+    pub fn border_mode_u(&self) -> Result<BorderMode, Error> {
+        BorderMode::try_from(unsafe { sys::ptextexture_get_border_mode_u(self.0) })
     }
 
     /// Return the border mode in the U direction.
-    pub fn border_mode_v(&self) -> BorderMode {
-        BorderMode::from(unsafe { sys::ptextexture_get_border_mode_v(self.0) })
+    pub fn border_mode_v(&self) -> Result<BorderMode, Error> {
+        BorderMode::try_from(unsafe { sys::ptextexture_get_border_mode_v(self.0) })
     }
 
     /// Return the edge filter mode.
-    pub fn edge_filter_mode(&self) -> EdgeFilterMode {
-        EdgeFilterMode::from(unsafe { sys::ptextexture_get_edge_filter_mode(self.0) })
+    pub fn edge_filter_mode(&self) -> Result<EdgeFilterMode, Error> {
+        EdgeFilterMode::try_from(unsafe { sys::ptextexture_get_edge_filter_mode(self.0) })
     }
 
     /// Access resolution and adjacency information about a face.

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -80,8 +80,8 @@ impl Texture {
     }
 
     /// Access resolution and adjacency information about a face.
-    pub fn face_info(&self, face_id: i32) -> &FaceInfo {
-        unsafe { sys::ptextexture_get_face_info(self.0, face_id) }
+    pub fn face_info(&self, face_id: i32) -> FaceInfo {
+        FaceInfo(*unsafe { sys::ptextexture_get_face_info(self.0, face_id) })
     }
 
     /// Access a single texel from the highest resolution texture .

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,7 +21,26 @@ impl From<ptex_sys::BorderMode> for BorderMode {
 }
 
 /// Type of data stored in texture file.
-pub type DataType = sys::DataType;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum DataType {
+    UInt8 = ptex_sys::DataType::UInt8.repr,
+    UInt16 = ptex_sys::DataType::UInt16.repr,
+    Float16 = ptex_sys::DataType::Float16.repr,
+    Float32 = ptex_sys::DataType::Float32.repr,
+}
+
+impl From<ptex_sys::DataType> for DataType {
+    fn from(data_type: ptex_sys::DataType) -> DataType {
+        match data_type {
+            ptex_sys::DataType::UInt8 => DataType::UInt8,
+            ptex_sys::DataType::UInt16 => DataType::UInt16,
+            ptex_sys::DataType::Float16 => DataType::Float16,
+            ptex_sys::DataType::Float32 => DataType::Float32,
+            _ => panic!("Unsupported datatype"),
+        }
+    }
+}
 
 /// How to handle transformation across edges when filtering.
 pub type EdgeFilterMode = sys::EdgeFilterMode;
@@ -149,12 +168,16 @@ pub struct OneValue;
 impl OneValue {
     /// Return the value of "1.0" for the specified DataType (1.0 (float), 255.0 (8bit), ...).
     pub fn get(data_type: crate::DataType) -> f32 {
-        sys::one_value(data_type)
+        sys::one_value(ptex_sys::DataType {
+            repr: data_type as u32,
+        })
     }
 
     /// Return the 1.0/value of "1.0" for the specified DataType (1/1.0 (float), 1/255.0 (8bit), ...).
     pub fn get_inverse(data_type: crate::DataType) -> f32 {
-        sys::one_value_inverse(data_type)
+        sys::one_value_inverse(ptex_sys::DataType {
+            repr: data_type as u32,
+        })
     }
 }
 
@@ -164,6 +187,8 @@ pub struct DataSize;
 impl DataSize {
     /// Return the size in bytes for the DataType.
     pub fn get(data_type: crate::DataType) -> i32 {
-        sys::data_size(data_type)
+        sys::data_size(ptex_sys::DataType {
+            repr: data_type as u32,
+        })
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,7 +16,24 @@ pub type EdgeId = sys::EdgeId;
 /// Type of base mesh for which the textures are defined.  A mesh
 /// can be triangle-based (with triangular textures) or quad-based
 /// (with rectangular textures). */
-pub type MeshType = sys::MeshType;
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MeshType {
+    Quad = ptex_sys::MeshType::Quad.repr,
+    Triangle = ptex_sys::MeshType::Triangle.repr,
+}
+
+impl From<ptex_sys::MeshType> for MeshType {
+    fn from(mesh_type: ptex_sys::MeshType) -> MeshType {
+        match mesh_type {
+            ptex_sys::MeshType::Quad => MeshType::Quad,
+            ptex_sys::MeshType::Triangle => MeshType::Triangle,
+            _ => {
+                panic!("Unrecognized meshtype")
+            }
+        }
+    }
+}
 
 /// Type of meta data entry.
 pub type MetaDataType = sys::MetaDataType;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,24 @@
 use crate::sys;
 
 /// How to handle mesh border when filtering.
-pub type BorderMode = sys::BorderMode;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum BorderMode {
+    Clamp = ptex_sys::BorderMode::Clamp.repr,
+    Black = ptex_sys::BorderMode::Black.repr,
+    Periodic = ptex_sys::BorderMode::Periodic.repr,
+}
+
+impl From<ptex_sys::BorderMode> for BorderMode {
+    fn from(border_mode: ptex_sys::BorderMode) -> BorderMode {
+        match border_mode {
+            ptex_sys::BorderMode::Clamp => BorderMode::Clamp,
+            ptex_sys::BorderMode::Black => BorderMode::Black,
+            ptex_sys::BorderMode::Periodic => BorderMode::Periodic,
+            _ => panic!("Unsupported border mode"),
+        }
+    }
+}
 
 /// Type of data stored in texture file.
 pub type DataType = sys::DataType;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,21 @@
 use crate::sys;
+use crate::Error;
+
+#[derive(Clone, PartialEq, Eq, Debug, thiserror::Error)]
+pub enum EnumConversionError {
+    #[error("Unsupported BorderMode value: {0}")]
+    BorderMode(u32),
+    #[error("Unsupported DataType value: {0}")]
+    DataType(u32),
+    #[error("Unsupported EdgeFilterMode value: {0}")]
+    EdgeFilterMode(u32),
+    #[error("Unsupported EdgeId value: {0}")]
+    EdgeId(u32),
+    #[error("Unsupported MeshType value: {0}")]
+    MeshType(u32),
+    #[error("Unsupported MetaDataType value: {0}")]
+    MetaDataType(u32),
+}
 
 /// How to handle mesh border when filtering.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -9,14 +26,15 @@ pub enum BorderMode {
     Periodic = ptex_sys::BorderMode::Periodic.repr,
 }
 
-impl From<ptex_sys::BorderMode> for BorderMode {
-    fn from(border_mode: ptex_sys::BorderMode) -> BorderMode {
-        match border_mode {
+impl TryFrom<ptex_sys::BorderMode> for BorderMode {
+    type Error = crate::Error;
+    fn try_from(border_mode: ptex_sys::BorderMode) -> Result<BorderMode, Self::Error> {
+        Ok(match border_mode {
             ptex_sys::BorderMode::Clamp => BorderMode::Clamp,
             ptex_sys::BorderMode::Black => BorderMode::Black,
             ptex_sys::BorderMode::Periodic => BorderMode::Periodic,
-            _ => panic!("Unsupported border mode"),
-        }
+            val => Err(EnumConversionError::BorderMode(val.repr))?,
+        })
     }
 }
 
@@ -30,15 +48,16 @@ pub enum DataType {
     Float32 = ptex_sys::DataType::Float32.repr,
 }
 
-impl From<ptex_sys::DataType> for DataType {
-    fn from(data_type: ptex_sys::DataType) -> DataType {
-        match data_type {
+impl TryFrom<ptex_sys::DataType> for DataType {
+    type Error = crate::Error;
+    fn try_from(data_type: ptex_sys::DataType) -> Result<DataType, Self::Error> {
+        Ok(match data_type {
             ptex_sys::DataType::UInt8 => DataType::UInt8,
             ptex_sys::DataType::UInt16 => DataType::UInt16,
             ptex_sys::DataType::Float16 => DataType::Float16,
             ptex_sys::DataType::Float32 => DataType::Float32,
-            _ => panic!("Unsupported datatype"),
-        }
+            val => Err(EnumConversionError::DataType(val.repr))?,
+        })
     }
 }
 
@@ -49,13 +68,14 @@ pub enum EdgeFilterMode {
     None = ptex_sys::EdgeFilterMode::None.repr,
     TangentVector = ptex_sys::EdgeFilterMode::TangentVector.repr,
 }
-impl From<ptex_sys::EdgeFilterMode> for EdgeFilterMode {
-    fn from(edge_filter_mode: ptex_sys::EdgeFilterMode) -> EdgeFilterMode {
-        match edge_filter_mode {
+impl TryFrom<ptex_sys::EdgeFilterMode> for EdgeFilterMode {
+    type Error = crate::Error;
+    fn try_from(edge_filter_mode: ptex_sys::EdgeFilterMode) -> Result<EdgeFilterMode, Self::Error> {
+        Ok(match edge_filter_mode {
             ptex_sys::EdgeFilterMode::None => EdgeFilterMode::None,
             ptex_sys::EdgeFilterMode::TangentVector => EdgeFilterMode::TangentVector,
-            _ => panic!("Unsupported edge filter mode"),
-        }
+            val => Err(EnumConversionError::EdgeFilterMode(val.repr))?,
+        })
     }
 }
 
@@ -70,15 +90,16 @@ pub enum EdgeId {
     Left = ptex_sys::EdgeId::Left.repr,
 }
 
-impl From<ptex_sys::EdgeId> for EdgeId {
-    fn from(edge_id: ptex_sys::EdgeId) -> EdgeId {
-        match edge_id {
+impl TryFrom<ptex_sys::EdgeId> for EdgeId {
+    type Error = crate::Error;
+    fn try_from(edge_id: ptex_sys::EdgeId) -> Result<EdgeId, Self::Error> {
+        Ok(match edge_id {
             ptex_sys::EdgeId::Bottom => EdgeId::Bottom,
             ptex_sys::EdgeId::Right => EdgeId::Right,
             ptex_sys::EdgeId::Top => EdgeId::Top,
             ptex_sys::EdgeId::Left => EdgeId::Left,
-            _ => panic!("Unsupported edge id"),
-        }
+            val => Err(EnumConversionError::EdgeId(val.repr))?,
+        })
     }
 }
 
@@ -92,15 +113,14 @@ pub enum MeshType {
     Triangle = ptex_sys::MeshType::Triangle.repr,
 }
 
-impl From<ptex_sys::MeshType> for MeshType {
-    fn from(mesh_type: ptex_sys::MeshType) -> MeshType {
-        match mesh_type {
+impl TryFrom<ptex_sys::MeshType> for MeshType {
+    type Error = crate::Error;
+    fn try_from(mesh_type: ptex_sys::MeshType) -> Result<MeshType, Self::Error> {
+        Ok(match mesh_type {
             ptex_sys::MeshType::Quad => MeshType::Quad,
             ptex_sys::MeshType::Triangle => MeshType::Triangle,
-            _ => {
-                panic!("Unrecognized meshtype")
-            }
-        }
+            val => Err(EnumConversionError::MeshType(val.repr))?,
+        })
     }
 }
 
@@ -116,17 +136,18 @@ pub enum MetaDataType {
     Double = ptex_sys::MetaDataType::Double.repr,
 }
 
-impl From<ptex_sys::MetaDataType> for MetaDataType {
-    fn from(meta_data_type: ptex_sys::MetaDataType) -> MetaDataType {
-        match meta_data_type {
+impl TryFrom<ptex_sys::MetaDataType> for MetaDataType {
+    type Error = crate::Error;
+    fn try_from(meta_data_type: ptex_sys::MetaDataType) -> Result<MetaDataType, Self::Error> {
+        Ok(match meta_data_type {
             ptex_sys::MetaDataType::String => MetaDataType::String,
             ptex_sys::MetaDataType::Int8 => MetaDataType::Int8,
             ptex_sys::MetaDataType::Int16 => MetaDataType::Int16,
             ptex_sys::MetaDataType::Int32 => MetaDataType::Int32,
             ptex_sys::MetaDataType::Float => MetaDataType::Float,
             ptex_sys::MetaDataType::Double => MetaDataType::Double,
-            _ => panic!("Unsupported meta data type"),
-        }
+            val => Err(EnumConversionError::MetaDataType(val.repr))?,
+        })
     }
 }
 
@@ -241,8 +262,8 @@ impl FaceInfo {
         self.0.set_resolution(res.into())
     }
 
-    pub fn adjacent_edge(&self, edge_id: i32) -> EdgeId {
-        EdgeId::from(self.0.adjacent_edge(edge_id))
+    pub fn adjacent_edge(&self, edge_id: i32) -> Result<EdgeId, Error> {
+        EdgeId::try_from(self.0.adjacent_edge(edge_id))
     }
 
     pub fn set_adjacent_edges(&mut self, e1: EdgeId, e2: EdgeId, e3: EdgeId, e4: EdgeId) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -43,7 +43,21 @@ impl From<ptex_sys::DataType> for DataType {
 }
 
 /// How to handle transformation across edges when filtering.
-pub type EdgeFilterMode = sys::EdgeFilterMode;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum EdgeFilterMode {
+    None = ptex_sys::EdgeFilterMode::None.repr,
+    TangentVector = ptex_sys::EdgeFilterMode::TangentVector.repr,
+}
+impl From<ptex_sys::EdgeFilterMode> for EdgeFilterMode {
+    fn from(edge_filter_mode: ptex_sys::EdgeFilterMode) -> EdgeFilterMode {
+        match edge_filter_mode {
+            ptex_sys::EdgeFilterMode::None => EdgeFilterMode::None,
+            ptex_sys::EdgeFilterMode::TangentVector => EdgeFilterMode::TangentVector,
+            _ => panic!("Unsupported edge filter mode"),
+        }
+    }
+}
 
 /// Edge IDs used in adjacency data in the Ptex::FaceInfo struct.
 /// Edge ID usage for triangle meshes is TBD.

--- a/src/types.rs
+++ b/src/types.rs
@@ -86,7 +86,30 @@ impl From<ptex_sys::MeshType> for MeshType {
 }
 
 /// Type of meta data entry.
-pub type MetaDataType = sys::MetaDataType;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum MetaDataType {
+    String = ptex_sys::MetaDataType::String.repr,
+    Int8 = ptex_sys::MetaDataType::Int8.repr,
+    Int16 = ptex_sys::MetaDataType::Int16.repr,
+    Int32 = ptex_sys::MetaDataType::Int32.repr,
+    Float = ptex_sys::MetaDataType::Float.repr,
+    Double = ptex_sys::MetaDataType::Double.repr,
+}
+
+impl From<ptex_sys::MetaDataType> for MetaDataType {
+    fn from(meta_data_type: ptex_sys::MetaDataType) -> MetaDataType {
+        match meta_data_type {
+            ptex_sys::MetaDataType::String => MetaDataType::String,
+            ptex_sys::MetaDataType::Int8 => MetaDataType::Int8,
+            ptex_sys::MetaDataType::Int16 => MetaDataType::Int16,
+            ptex_sys::MetaDataType::Int32 => MetaDataType::Int32,
+            ptex_sys::MetaDataType::Float => MetaDataType::Float,
+            ptex_sys::MetaDataType::Double => MetaDataType::Double,
+            _ => panic!("Unsupported meta data type"),
+        }
+    }
+}
 
 /// Pixel resolution of a given texture.
 /// The resolution is stored in log form: ulog2 = log2(ures), vlog2 = log2(vres)).

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -105,7 +105,9 @@ impl Writer {
                 ptex_sys::MeshType {
                     repr: mesh_type as u32,
                 },
-                data_type,
+                ptex_sys::DataType {
+                    repr: data_type as u32,
+                },
                 num_channels,
                 alpha_channel,
                 num_faces,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -102,7 +102,9 @@ impl Writer {
         let writer = unsafe {
             sys::ptexwriter_open(
                 filename_str,
-                mesh_type,
+                ptex_sys::MeshType {
+                    repr: mesh_type as u32,
+                },
                 data_type,
                 num_channels,
                 alpha_channel,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -160,7 +160,7 @@ impl Writer {
         stride: i32,
     ) -> bool {
         unsafe {
-            sys::ptexwriter_write_face(self.0, face_id, face_info, texel_buf.as_u8_ptr(), stride)
+            sys::ptexwriter_write_face(self.0, face_id, &face_info.0, texel_buf.as_u8_ptr(), stride)
         }
     }
 }

--- a/tests/reader_test.rs
+++ b/tests/reader_test.rs
@@ -27,9 +27,9 @@ fn test_cache_get() -> Result<()> {
     assert!(!texture.has_edits());
     assert!(texture.has_mip_maps());
     assert_eq!(filename, texture.filename());
-    assert_eq!(texture.mesh_type(), ptex::MeshType::Quad);
-    assert_eq!(texture.data_type(), ptex::DataType::UInt16);
-    assert_eq!(texture.edge_filter_mode(), ptex::EdgeFilterMode::None);
+    assert_eq!(texture.mesh_type()?, ptex::MeshType::Quad);
+    assert_eq!(texture.data_type()?, ptex::DataType::UInt16);
+    assert_eq!(texture.edge_filter_mode()?, ptex::EdgeFilterMode::None);
 
     Ok(())
 }
@@ -46,7 +46,7 @@ fn test_face_info() -> Result<()> {
     assert!(!face_info.is_constant());
     assert!(!face_info.is_neighborhood_constant());
     assert!(!face_info.is_subface());
-    assert_eq!(face_info.adjacent_edge(0), ptex::EdgeId::Top);
+    assert_eq!(face_info.adjacent_edge(0)?, ptex::EdgeId::Top);
 
     let face_info = texture.face_info(0);
     assert_eq!(face_info.adjacent_face(0), 3);
@@ -75,10 +75,10 @@ fn test_face_info_set_adjfaces() -> Result<()> {
     assert_eq!(face_info.adjacent_face(3), 4);
 
     let mut face_info = texture.face_info(1);
-    assert_eq!(face_info.adjacent_edge(0), ptex::EdgeId::Top);
-    assert_eq!(face_info.adjacent_edge(1), ptex::EdgeId::Left);
-    assert_eq!(face_info.adjacent_edge(2), ptex::EdgeId::Bottom);
-    assert_eq!(face_info.adjacent_edge(3), ptex::EdgeId::Right);
+    assert_eq!(face_info.adjacent_edge(0)?, ptex::EdgeId::Top);
+    assert_eq!(face_info.adjacent_edge(1)?, ptex::EdgeId::Left);
+    assert_eq!(face_info.adjacent_edge(2)?, ptex::EdgeId::Bottom);
+    assert_eq!(face_info.adjacent_edge(3)?, ptex::EdgeId::Right);
 
     face_info.set_adjacent_edges(
         ptex::EdgeId::Left,
@@ -86,10 +86,10 @@ fn test_face_info_set_adjfaces() -> Result<()> {
         ptex::EdgeId::Top,
         ptex::EdgeId::Bottom,
     );
-    assert_eq!(face_info.adjacent_edge(0), ptex::EdgeId::Left);
-    assert_eq!(face_info.adjacent_edge(1), ptex::EdgeId::Right);
-    assert_eq!(face_info.adjacent_edge(2), ptex::EdgeId::Top);
-    assert_eq!(face_info.adjacent_edge(3), ptex::EdgeId::Bottom);
+    assert_eq!(face_info.adjacent_edge(0)?, ptex::EdgeId::Left);
+    assert_eq!(face_info.adjacent_edge(1)?, ptex::EdgeId::Right);
+    assert_eq!(face_info.adjacent_edge(2)?, ptex::EdgeId::Top);
+    assert_eq!(face_info.adjacent_edge(3)?, ptex::EdgeId::Bottom);
 
     Ok(())
 }

--- a/tests/reader_test.rs
+++ b/tests/reader_test.rs
@@ -67,14 +67,14 @@ fn test_face_info_set_adjfaces() -> Result<()> {
     assert_eq!(face_info.adjacent_face(2), -1);
     assert_eq!(face_info.adjacent_face(3), -1);
 
-    let mut face_info = *texture.face_info(0);
+    let mut face_info = texture.face_info(0);
     face_info.set_adjacent_faces(1, 2, 3, 4);
     assert_eq!(face_info.adjacent_face(0), 1);
     assert_eq!(face_info.adjacent_face(1), 2);
     assert_eq!(face_info.adjacent_face(2), 3);
     assert_eq!(face_info.adjacent_face(3), 4);
 
-    let mut face_info = *texture.face_info(1);
+    let mut face_info = texture.face_info(1);
     assert_eq!(face_info.adjacent_edge(0), ptex::EdgeId::Top);
     assert_eq!(face_info.adjacent_edge(1), ptex::EdgeId::Left);
     assert_eq!(face_info.adjacent_edge(2), ptex::EdgeId::Bottom);
@@ -134,7 +134,7 @@ fn test_faceinfo_set_resolution() -> Result<()> {
     assert_eq!(res.v(), base.pow(7));
 
     let res = ptex::Res::from_uv(3, 4);
-    let mut face_info = *texture.face_info(0);
+    let mut face_info = texture.face_info(0);
     face_info.set_resolution(res);
 
     let res = face_info.resolution();


### PR DESCRIPTION
I'm uncertain if you'll want this patch, but it moves `MeshType` to using an enum instead of the alias for the `ptex_sys::MeshType` u32 wrapper.  Here is a patch in case such a thing seems warranted.
