### PR TITLE
Add tests for funky enum values

### DIFF
--- a/ptex-sys/tests/integration_test.rs
+++ b/ptex-sys/tests/integration_test.rs
@@ -27,3 +27,69 @@ fn open_writer() {
     assert!(!writer.is_null());
     assert!(error_str.is_empty());
 }
+
+#[test]
+fn funky_values1() {
+    let filename = "out.ptx";
+    let alpha_channel = -1;
+    let num_channels = 3;
+    let num_faces = 9;
+    let genmipmaps = false;
+    // The last variant in the enum.
+    let mut meshtype = ptex_sys::MeshType::Quad;
+    meshtype.repr += 1;
+    let mut datatype = ptex_sys::DataType::Float32;
+
+    let_cxx_string!(error_str = "");
+
+    let writer = unsafe {
+        ptex_sys::ptexwriter_open(
+            filename,
+            meshtype,
+            datatype,
+            num_channels,
+            alpha_channel,
+            num_faces,
+            genmipmaps,
+            error_str.as_mut().get_unchecked_mut(),
+        )
+    };
+    assert!(writer.is_null());
+    assert_eq!(
+        error_str.to_str(),
+        Ok("PtexWriter error: Invalid mesh type")
+    );
+}
+
+#[test]
+fn funky_values2() {
+    let filename = "out.ptx";
+    let alpha_channel = -1;
+    let num_channels = 3;
+    let num_faces = 9;
+    let genmipmaps = false;
+    let mut meshtype = ptex_sys::MeshType::Quad;
+    // The last variant in the enum.
+    let mut datatype = ptex_sys::DataType::Float32;
+    datatype.repr += 1;
+
+    let_cxx_string!(error_str = "");
+
+    let writer = unsafe {
+        ptex_sys::ptexwriter_open(
+            filename,
+            meshtype,
+            datatype,
+            num_channels,
+            alpha_channel,
+            num_faces,
+            genmipmaps,
+            error_str.as_mut().get_unchecked_mut(),
+        )
+    };
+    assert!(writer.is_null());
+    assert_eq!(
+        error_str.to_str(),
+        Ok("PtexWriter error: Invalid data type")
+    );
+}


### PR DESCRIPTION
This adds a couple of tests based on the `open_writer` passing invalid `MeshType` and `DataType` values.
These were the easiest to test, just because they could be based upon the existing test.

This is part of checking whether the panics/Error cases in the `TryFrom` implementation of PR #6 are actually reachable.
With these tests producing errors and null writers, it appears that these two might not be reachable.

Let me know if you would like me to continue trying to come up with tests for the rest of the enums.