### PR TITLE
Funky values continued

### DIFF
--- a/ptex-sys/tests/integration_test.rs
+++ b/ptex-sys/tests/integration_test.rs
@@ -1,5 +1,8 @@
 use cxx::let_cxx_string;
-use ptex_sys::{ptexwriter_write_face, EdgeId, FaceInfo, PtexWriter};
+use ptex_sys::{
+    ptexcache_create, ptexcache_get, ptextexture_get_face_info, ptexwriter_close,
+    ptexwriter_write_face, EdgeId, FaceInfo, PtexCache, PtexWriter,
+};
 
 #[test]
 fn open_writer() {
@@ -95,8 +98,7 @@ fn funky_values_data_type() {
     );
 }
 
-fn make_test_writer() -> *mut PtexWriter {
-    let filename = "out.ptx";
+fn make_test_writer(filename: &str) -> *mut PtexWriter {
     let alpha_channel = -1;
     let num_channels = 3;
     let num_faces = 9;
@@ -124,7 +126,7 @@ fn make_test_writer() -> *mut PtexWriter {
 
 #[test]
 fn funky_values_edge_id() {
-    let writer = make_test_writer();
+    let writer = make_test_writer("funky_edge_ids.ptex");
     let mut face_info = FaceInfo::default();
     // Left currently being the last variant in `EdgeId`.
     let mut e1 = EdgeId::Left;
@@ -138,9 +140,30 @@ fn funky_values_edge_id() {
     let stride = 0;
     face_info.set_adjacent_edges(e1, e2, e3, e4);
     let data = [0_u8; 9];
-    let wrote_face = unsafe {
-        ptexwriter_write_face(writer, 0, &face_info, data.as_ptr(), stride)
+    let wrote_face = unsafe { ptexwriter_write_face(writer, 0, &face_info, data.as_ptr(), stride) };
+    assert!(wrote_face);
+    unsafe {
+        ptexwriter_close(writer);
+    }
+    let cache: *mut PtexCache = unsafe { ptexcache_create(1, 1024, true) };
+    assert!(!cache.is_null());
+    let_cxx_string!(error_str = "");
+    let texture = unsafe {
+        ptexcache_get(
+            cache,
+            "funky_edge_ids.ptex",
+            error_str.as_mut().get_unchecked_mut(),
+        )
     };
-    // Currently this fails, as it seems it is possible to write funky values in place of EdgeIds.
-    assert_eq!(wrote_face, false);
+    assert!(!texture.is_null());
+    let face_info = unsafe { ptextexture_get_face_info(texture, 0) };
+    for i in 0..face_info.adjedges {
+        let edge_id = face_info.adjacent_edge(i.into());
+        assert!(
+            edge_id == EdgeId::Bottom
+                || edge_id == EdgeId::Right
+                || edge_id == EdgeId::Top
+                || edge_id == EdgeId::Left
+        );
+    }
 }

--- a/ptex-sys/tests/integration_test.rs
+++ b/ptex-sys/tests/integration_test.rs
@@ -29,7 +29,7 @@ fn open_writer() {
 }
 
 #[test]
-fn funky_values1() {
+fn funky_values_mesh_type() {
     let filename = "out.ptx";
     let alpha_channel = -1;
     let num_channels = 3;
@@ -38,7 +38,7 @@ fn funky_values1() {
     // The last variant in the enum.
     let mut meshtype = ptex_sys::MeshType::Quad;
     meshtype.repr += 1;
-    let mut datatype = ptex_sys::DataType::Float32;
+    let datatype = ptex_sys::DataType::Float32;
 
     let_cxx_string!(error_str = "");
 
@@ -62,13 +62,13 @@ fn funky_values1() {
 }
 
 #[test]
-fn funky_values2() {
+fn funky_values_data_type() {
     let filename = "out.ptx";
     let alpha_channel = -1;
     let num_channels = 3;
     let num_faces = 9;
     let genmipmaps = false;
-    let mut meshtype = ptex_sys::MeshType::Quad;
+    let meshtype = ptex_sys::MeshType::Quad;
     // The last variant in the enum.
     let mut datatype = ptex_sys::DataType::Float32;
     datatype.repr += 1;


### PR DESCRIPTION
This adds some (failing) tests for the `EdgeId` enum.  It doesn't appear as though the ptex c++ library currently catches these funky values as it does for the `MeshType` and `DataType` tests previously added.

My assumption is it might be worthwhile looking into fixing these upstream, if it is a safe assumtion that writing isn't really
a hot path where the additional checks could be problematic?  Since this appears to need more work, i've currently set them into draft mode.

While doing this I noticed some renaming/clippy stuff on the previously added tests.
