### PR TITLE
Add PtexWriter setBorderModes/setEdgeMode functionality

### DIFF
--- a/ptex-sys/src/lib.rs
+++ b/ptex-sys/src/lib.rs
@@ -500,6 +500,12 @@ pub mod ffi {
             u_border_mode: BorderMode,
             v_border_mode: BorderMode,
         );
+
+        #[namespace = "Ptex::sys"]
+        unsafe fn ptexwriter_set_edge_filter_mode(
+            writer: *mut PtexWriter,
+            edge_filter_mode: EdgeFilterMode,
+        );
     }
 }
 

--- a/ptex-sys/src/lib.rs
+++ b/ptex-sys/src/lib.rs
@@ -493,6 +493,13 @@ pub mod ffi {
             data: *const u8,
             stride: i32,
         ) -> bool;
+
+        #[namespace = "Ptex::sys"]
+        unsafe fn ptexwriter_set_border_modes(
+            writer: *mut PtexWriter,
+            u_border_mode: BorderMode,
+            v_border_mode: BorderMode,
+        );
     }
 }
 

--- a/ptex-sys/src/ptex-sys.h
+++ b/ptex-sys/src/ptex-sys.h
@@ -75,6 +75,14 @@ inline void ptexwriter_set_border_modes(
     writer->setBorderModes(u_border_mode, v_border_mode);
 }
 
+/// Set edge filter mode for writer.
+inline void ptexwriter_set_edge_filter_mode(
+    PtexWriter *writer,
+    EdgeFilterMode edge_filter_mode)
+{
+    writer->setEdgeFilterMode(edge_filter_mode);
+}
+
 // struct Res
 
 /// Create a default-constructed Res.

--- a/ptex-sys/src/ptex-sys.h
+++ b/ptex-sys/src/ptex-sys.h
@@ -329,7 +329,11 @@ inline DataType ptextexture_get_datatype(PtexTexture const *texture)
 inline BorderMode ptextexture_get_border_mode_u(PtexTexture const *texture)
 {
     if (texture) {
-        return const_cast<PtexTexture *>(texture)->uBorderMode();
+        BorderMode mode = const_cast<PtexTexture *>(texture)->uBorderMode();
+        if (mode > BorderMode::m_periodic) {
+            return BorderMode::m_clamp;
+        }
+        return mode;
     }
     return BorderMode::m_clamp;
 }
@@ -337,7 +341,11 @@ inline BorderMode ptextexture_get_border_mode_u(PtexTexture const *texture)
 inline BorderMode ptextexture_get_border_mode_v(PtexTexture const *texture)
 {
     if (texture) {
-        return const_cast<PtexTexture *>(texture)->vBorderMode();
+        BorderMode mode = const_cast<PtexTexture *>(texture)->uBorderMode();
+        if (mode > BorderMode::m_periodic) {
+            return BorderMode::m_clamp;
+        }
+        return mode;
     }
     return BorderMode::m_clamp;
 }

--- a/ptex-sys/src/ptex-sys.h
+++ b/ptex-sys/src/ptex-sys.h
@@ -353,7 +353,11 @@ inline BorderMode ptextexture_get_border_mode_v(PtexTexture const *texture)
 inline EdgeFilterMode ptextexture_get_edge_filter_mode(PtexTexture const *texture)
 {
     if (texture) {
-        return const_cast<PtexTexture *>(texture)->edgeFilterMode();
+        EdgeFilterMode mode = const_cast<PtexTexture *>(texture)->edgeFilterMode();
+        if (mode > EdgeFilterMode::efm_tanvec) {
+            return EdgeFilterMode::efm_none;
+        }
+        return mode;
     }
     return EdgeFilterMode::efm_none;
 }

--- a/ptex-sys/src/ptex-sys.h
+++ b/ptex-sys/src/ptex-sys.h
@@ -66,6 +66,15 @@ inline bool ptexwriter_write_face(
     return writer->writeFace(face_id, face_info, (void*)data, stride);
 }
 
+/// Set border modes for writer
+inline void ptexwriter_set_border_modes(
+    PtexWriter *writer,
+    BorderMode u_border_mode,
+    BorderMode v_border_mode)
+{
+    writer->setBorderModes(u_border_mode, v_border_mode);
+}
+
 // struct Res
 
 /// Create a default-constructed Res.

--- a/ptex-sys/tests/integration_test.rs
+++ b/ptex-sys/tests/integration_test.rs
@@ -1,8 +1,9 @@
 use cxx::let_cxx_string;
 use ptex_sys::{
     ptexcache_create, ptexcache_get, ptextexture_get_border_mode_u, ptextexture_get_border_mode_v,
-    ptextexture_get_face_info, ptexwriter_close, ptexwriter_set_border_modes,
-    ptexwriter_write_face, BorderMode, EdgeId, FaceInfo, PtexCache, PtexWriter,
+    ptextexture_get_edge_filter_mode, ptextexture_get_face_info, ptexwriter_close,
+    ptexwriter_set_border_modes, ptexwriter_set_edge_filter_mode, ptexwriter_write_face,
+    BorderMode, EdgeFilterMode, EdgeId, FaceInfo, PtexCache, PtexWriter,
 };
 
 #[test]
@@ -201,5 +202,39 @@ fn funky_values_border_modes() {
     unsafe {
         assert!(ptextexture_get_border_mode_u(texture) != border_mode);
         assert!(ptextexture_get_border_mode_v(texture) != border_mode);
+    }
+}
+
+#[test]
+fn funky_values_edge_filter_mode() {
+    let writer = make_test_writer("funky_edge_filter_mode.ptex");
+    // The last variant in the enum.
+    let mut edge_filter_mode = EdgeFilterMode::TangentVector;
+    edge_filter_mode.repr += 1;
+    unsafe {
+        ptexwriter_set_edge_filter_mode(writer, edge_filter_mode);
+    }
+    let stride = 0;
+    let mut face_info = FaceInfo::default();
+    face_info.set_adjacent_edges(EdgeId::Bottom, EdgeId::Right, EdgeId::Top, EdgeId::Left);
+    let data = [0_u8; 9];
+    let wrote_face = unsafe { ptexwriter_write_face(writer, 0, &face_info, data.as_ptr(), stride) };
+    assert!(wrote_face);
+    unsafe {
+        ptexwriter_close(writer);
+    }
+    let cache: *mut PtexCache = unsafe { ptexcache_create(1, 1024, true) };
+    assert!(!cache.is_null());
+    let_cxx_string!(error_str = "");
+    let texture = unsafe {
+        ptexcache_get(
+            cache,
+            "funky_edge_filter_mode.ptex",
+            error_str.as_mut().get_unchecked_mut(),
+        )
+    };
+    assert!(!texture.is_null());
+    unsafe {
+        assert!(ptextexture_get_edge_filter_mode(texture) != edge_filter_mode);
     }
 }


### PR DESCRIPTION
These add (failing) tests for the funky values series,
It appears that the ptex library doesn't check/truncate these values, 
as such they do end up being written to/read from the library.

I wasn't sure if that was perhaps something we should do in this crate in
`ptextexture_get_border_mode_{u,v}` and `ptextexture_get_edge_filter_mode`, and if so what the defaults should be:
I would suppose `EdgeFilterMode::None`, and `BorderMode::Black`?

Or if this is something which should instead be done in the upstream library.
